### PR TITLE
Fix use of alignas for clang, use alignas unconditionally on all systems.

### DIFF
--- a/src/column.h
+++ b/src/column.h
@@ -14,12 +14,6 @@
 #include <utility>
 #include <cmath>
 
-#ifdef _WIN32
-#define ALIGN_8 alignas(8)
-#else
-#define ALIGN_8 __attribute__ ((aligned (8)))
-#endif
-
 class DataSet;
 
 typedef struct
@@ -28,7 +22,7 @@ typedef struct
     int length;
     int capacity;
 
-    char values[8] ALIGN_8;
+    alignas(8) char values[8];
 
 } Block;
 


### PR DESCRIPTION
The position of the alignas() attribute within the line is not accepted by clang. I've changed it to one that is accepted by both clang and gcc (tested on Windows). According to the documentation, it would be accepted even by MSVC, which is though not used with R.

The non-standard "aligned" attribute could also be used at this position, and also on Windows, but both clang and gcc by now support the standard alignas() attribute, so the  patch uses just that for simplicity.

With this trivial fix, the package builds and checks fine on my Windows/aarch64 using experimental LLVM 17 toolchain (an experimental build of Rtools).